### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-update-using-python.yml
+++ b/.github/workflows/auto-update-using-python.yml
@@ -15,6 +15,9 @@ jobs:
   build:
     # Display name of the job in the GitHub Actions UI
     name: Execute Python Script and Push Changes
+    # Specify the permissions required for this job
+    permissions:
+      contents: write
     # Specify the type of runner (a fresh Ubuntu VM)
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/smsrail-com-documentation/security/code-scanning/1](https://github.com/Strong-Foundation/smsrail-com-documentation/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow requires the ability to push changes to the repository, we will grant `contents: write` permission. All other permissions will be omitted to minimize the scope of access. The `permissions` block will be added at the job level (`build`) to ensure it applies only to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
